### PR TITLE
fixed file.create overwrite bug

### DIFF
--- a/src/lib/File.luau
+++ b/src/lib/File.luau
@@ -64,7 +64,7 @@ function File.create(filePath, initialContents, overwrite)
 
 	if fs.isFile(filePath) then
 		if overwrite then
-			fs.removeDir(filePath)
+			fs.removeFile(filePath)
 		else
 			error(`Cannot create a new file. A file already exists at that path({filePath})`)
 		end


### PR DESCRIPTION
When `File.create` is called with overwrite enabled and the file already exists, `File.create` calls a wrong function (`fs.removeDir` instead of `fs.removeFile`) resulting in an error.
Replaced `fs.removeDir` with `fs.removeFile` to fix the bug.